### PR TITLE
Add option to display individual market board listings

### DIFF
--- a/RebornToolbox/Features/MBShoppingList/MBShoppingList.Config.cs
+++ b/RebornToolbox/Features/MBShoppingList/MBShoppingList.Config.cs
@@ -10,4 +10,5 @@ public class MBShoppingList_Config
     public bool UseVnavPathing { get; set; } = false;
     public bool RemoveQuantityAutomatically { get; set; } = false;
     public bool AllCharactersInventory { get; set; } = false;
+    public bool ShowIndividualListings { get; set; } = false;
 }


### PR DESCRIPTION
This update introduces a new configuration toggle to show individual market board listings in the shopping list feature. When enabled, users can now view detailed item listings, including quantity and total price, with travel options via LifeStream integration. The default behavior remains unchanged unless the option is explicitly enabled.